### PR TITLE
fix: Read doubles in scientific format from text

### DIFF
--- a/Utilities/StringFunctions.cpp
+++ b/Utilities/StringFunctions.cpp
@@ -245,6 +245,15 @@ namespace StringFunctions
 		return true;
 	}
 
+	// HACK: Default read operator for double sometimes miss-interprets doubles in format Xe-0Y. stod is used to overcome the problem.
+	template <>
+	double GetValueFromStream<double>(std::istream& _is)
+	{
+		if (const std::string str = GetValueFromStream<std::string>(_is); !str.empty())
+			return std::stod(str);
+		return {};
+	}
+
 	template <>
 	std::string GetValueFromStream<std::string>(std::istream& _is)
 	{
@@ -257,7 +266,10 @@ namespace StringFunctions
 	std::vector<double> GetValueFromStream<std::vector<double>>(std::istream& _is)
 	{
 		std::vector<double> res;
-		std::copy(std::istream_iterator<double>{ _is }, std::istream_iterator<double>{}, std::back_inserter(res));
+		// HACK: Default read operator for double sometimes miss-interprets doubles in format Xe-0Y -> the following does not work
+		//std::copy(std::istream_iterator<double>{ _is }, std::istream_iterator<double>{}, std::back_inserter(res));
+		while (!_is.eof() && _is.rdbuf()->in_avail() != 0)
+			res.push_back(GetValueFromStream<double>(_is));
 		return res;
 	}
 

--- a/Utilities/StringFunctions.h
+++ b/Utilities/StringFunctions.h
@@ -60,6 +60,7 @@ namespace StringFunctions
 	std::string GetRestOfLine(std::istream& _is);												// Returns the full string until the end-of-line without trailing whitespaces.
 	template<typename T> T GetValueFromStream(std::istream& _is) { T v{}; _is >> v; return v; }	// Returns the next value from the stream and advances stream's iterator correspondingly.
 	template<> bool GetValueFromStream(std::istream& _is);										// Returns the next value from the stream and advances stream's iterator correspondingly. Overload for bool type.
+	template<> double GetValueFromStream(std::istream& _is);									// Returns the next value from the stream and advances stream's iterator correspondingly. Overload for double type.
 	template<> std::string GetValueFromStream(std::istream& _is);								// Returns the next value from the stream and advances stream's iterator correspondingly. Overload for string type.
 	template<> std::vector<double> GetValueFromStream(std::istream& _is);						// Returns the next value from the stream and advances stream's iterator correspondingly. Overload for vector<double>.
 	template<> std::vector<std::string> GetValueFromStream(std::istream& _is);					// Returns the next value from the stream and advances stream's iterator correspondingly. Overload for vector<string>.


### PR DESCRIPTION
Add workaround to read doubles in format Xe-0Y from istream.